### PR TITLE
feat: Implement full RRULE to WindowOption conversion

### DIFF
--- a/window/conversions.go
+++ b/window/conversions.go
@@ -62,16 +62,66 @@ func convertRRULEtoWindowOption(ruleString string) (*WindowOption, error) {
 	}
 
 	// Rules specific logic
+	rule := rules.Rule{IntervalType: rules.RuleTypeInclusion}
+	hasRule := false
+
 	if len(rr.OrigOptions.Byweekday) != 0 {
 		var wkDays []time.Weekday
 		for _, wk := range rr.OrigOptions.Byweekday {
 			wkDays = append(wkDays, MapRRuleWeekToWeekday(wk))
 		}
+		rule.DayOfWeeks = wkDays
+		hasRule = true
+	}
 
-		rulesList = append(rulesList, rules.Rule{
-			IntervalType: rules.RuleTypeInclusion,
-			DayOfWeeks:   wkDays,
-		})
+	if len(rr.OrigOptions.Bymonth) != 0 {
+		var months []time.Month
+		for _, m := range rr.OrigOptions.Bymonth {
+			months = append(months, (time.Month)(m))
+		}
+		rule.Months = months
+		hasRule = true
+	}
+
+	if len(rr.OrigOptions.Bymonthday) != 0 {
+		var monthDays []uint32
+		for _, day := range rr.OrigOptions.Bymonthday {
+			monthDays = append(monthDays, (uint32)(day))
+		}
+		rule.MonthDays = monthDays
+		hasRule = true
+	}
+
+	// For time, we can only represent a single time or a single range.
+	// RRULE can have multiple values, e.g., BYHOUR=8,18.
+	// The current TimeRange struct does not support this.
+	// For now, we will only take the first value for each.
+	timeRef := rules.TimeReference{}
+	hasTimeRef := false
+	if len(rr.OrigOptions.Byhour) > 0 {
+		timeRef.Hour = rr.OrigOptions.Byhour[0]
+		hasTimeRef = true
+	}
+	if len(rr.OrigOptions.Byminute) > 0 {
+		timeRef.Minute = rr.OrigOptions.Byminute[0]
+		hasTimeRef = true
+	}
+	if len(rr.OrigOptions.Bysecond) > 0 {
+		timeRef.Second = rr.OrigOptions.Bysecond[0]
+		hasTimeRef = true
+	}
+
+	if hasTimeRef {
+		rule.TimeRange = &rules.TimeRange{
+			StartTimeReference: timeRef,
+			// For now, we assume a single point in time, so start and end are the same.
+			EndTimeReference: timeRef,
+		}
+		hasRule = true
+	}
+
+	if hasRule {
+		rulesList = append(rulesList, rule)
 	}
 
 	return &WindowOption{

--- a/window/conversions_test.go
+++ b/window/conversions_test.go
@@ -299,6 +299,94 @@ func TestRRULEConversion(t *testing.T) {
 			},
 			expectedError: false,
 		},
+		{
+			name:        "Monthly by month",
+			rruleString: "FREQ=MONTHLY;BYMONTH=1",
+			expectedWindowOption: WindowOption{
+				IntervalOption: interval.IntervalOption{
+					AnchorDate:    now,
+					StartDate:     helper.ToPointer(now),
+					EndDate:       nil,
+					Size:          &inf,
+					FrequencyUnit: interval.FrequencyMonth,
+					IntervalValue: uint32(1),
+				},
+				Rules: []rules.Rule{
+					{
+						IntervalType: rules.RuleTypeInclusion,
+						Months:       []time.Month{time.January},
+					},
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name:        "Yearly by month day",
+			rruleString: "FREQ=YEARLY;BYMONTHDAY=15",
+			expectedWindowOption: WindowOption{
+				IntervalOption: interval.IntervalOption{
+					AnchorDate:    now,
+					StartDate:     helper.ToPointer(now),
+					EndDate:       nil,
+					Size:          &inf,
+					FrequencyUnit: interval.FrequencyYear,
+					IntervalValue: uint32(1),
+				},
+				Rules: []rules.Rule{
+					{
+						IntervalType: rules.RuleTypeInclusion,
+						MonthDays:    []uint32{15},
+					},
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name:        "Daily by hour, minute, second",
+			rruleString: "FREQ=DAILY;BYHOUR=10;BYMINUTE=30;BYSECOND=5",
+			expectedWindowOption: WindowOption{
+				IntervalOption: interval.IntervalOption{
+					AnchorDate:    now,
+					StartDate:     helper.ToPointer(now),
+					EndDate:       nil,
+					Size:          &inf,
+					FrequencyUnit: interval.FrequencyDay,
+					IntervalValue: uint32(1),
+				},
+				Rules: []rules.Rule{
+					{
+						IntervalType: rules.RuleTypeInclusion,
+						TimeRange: &rules.TimeRange{
+							StartTimeReference: rules.TimeReference{Hour: 10, Minute: 30, Second: 5},
+							EndTimeReference:   rules.TimeReference{Hour: 10, Minute: 30, Second: 5},
+						},
+					},
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name:        "Weekly on Monday in June",
+			rruleString: "FREQ=WEEKLY;BYDAY=MO;BYMONTH=6",
+			expectedWindowOption: WindowOption{
+				IntervalOption: interval.IntervalOption{
+					AnchorDate:    now,
+					StartDate:     helper.ToPointer(now),
+					EndDate:       nil,
+					Size:          &inf,
+					FrequencyUnit: interval.FrequencyWeek,
+					IntervalValue: uint32(1),
+				},
+				Rules: []rules.Rule{
+					{
+						IntervalType: rules.RuleTypeInclusion,
+						DayOfWeeks:   []time.Weekday{time.Monday},
+						Months:       []time.Month{time.June},
+					},
+				},
+			},
+			expectedError: false,
+		},
 		// {
 		// 	name:        "Simple Daily Interval (1) With DTstart (20250101000000)",
 		// 	rruleString: "DTSTART=20240101T090000Z;FREQ=DAILY;INTERVAL=1",


### PR DESCRIPTION
This commit implements the conversion of the remaining RRULE components to the library's `WindowOption` struct.

The following RRULE components are now supported:
- BYHOUR, BYMINUTE, BYSECOND: Mapped to the `TimeRange` field in `rules.Rule`. A limitation is that only the first value is used if multiple are provided.
- BYMONTH, BYMONTHDAY: Mapped to the `Months` and `MonthDays` fields in `rules.Rule`.

The logic has been refactored to combine all `BY...` rules into a single `rules.Rule` object, which correctly reflects the AND logic of RRULE.

Unit tests have been added to `window/conversions_test.go` to cover all the new conversions and ensure the logic is correct.