### PR TITLE
Handle RRULE occurrence filters without set position metadata

### DIFF
--- a/rules/entities.go
+++ b/rules/entities.go
@@ -1,6 +1,12 @@
 package rules
 
-import "time"
+import (
+	"time"
+
+	"github.com/copito/coptime/common"
+)
+
+type SubWindowFilter func([]common.SubWindowResult) []common.SubWindowResult
 
 type RuleType int32
 
@@ -42,4 +48,5 @@ type Rule struct {
 	MonthDays    []uint32
 	Months       []time.Month
 	Years        []uint32
+	Filter       SubWindowFilter
 }

--- a/rules/filters.go
+++ b/rules/filters.go
@@ -1,0 +1,67 @@
+package rules
+
+import (
+	"sort"
+
+	"github.com/copito/coptime/common"
+)
+
+// NewOccurrenceFilter returns a filter that selects the nth occurrences from the
+// provided slice of sub-windows based on the supplied indexes. Positive indexes
+// select from the start (1-based) and negative indexes select from the end.
+func NewOccurrenceFilter(indexes []int) SubWindowFilter {
+	if len(indexes) == 0 {
+		return nil
+	}
+
+	// Copy indexes to avoid mutating the caller's slice when the closure runs.
+	positions := append([]int(nil), indexes...)
+
+	return func(windows []common.SubWindowResult) []common.SubWindowResult {
+		if len(positions) == 0 || len(windows) == 0 {
+			return windows
+		}
+
+		sorted := append([]common.SubWindowResult(nil), windows...)
+		sort.Slice(sorted, func(i, j int) bool {
+			return sorted[i].Start.Before(sorted[j].Start)
+		})
+
+		selected := make([]common.SubWindowResult, 0, len(positions))
+		used := make(map[int]struct{}, len(positions))
+
+		for _, pos := range positions {
+			if pos == 0 {
+				continue
+			}
+
+			idx := 0
+			if pos > 0 {
+				idx = pos - 1
+			} else {
+				idx = len(sorted) + pos
+			}
+
+			if idx < 0 || idx >= len(sorted) {
+				continue
+			}
+
+			if _, exists := used[idx]; exists {
+				continue
+			}
+
+			selected = append(selected, sorted[idx])
+			used[idx] = struct{}{}
+		}
+
+		sort.Slice(selected, func(i, j int) bool {
+			return selected[i].Start.Before(selected[j].Start)
+		})
+
+		if len(selected) == 0 {
+			return []common.SubWindowResult{}
+		}
+
+		return selected
+	}
+}

--- a/rules/subwindow.go
+++ b/rules/subwindow.go
@@ -137,50 +137,101 @@ func adjustFrequencyUnitForRuleEvaluation(unit interval.Frequency) interval.Freq
 }
 
 func GenerateSubWindowsForRuleType(direction interval.Direction, unit interval.Frequency, start time.Time, end time.Time, rules []Rule, loc *time.Location) []common.SubWindowResult {
+	subWindows := make([]common.SubWindowResult, 0, len(rules))
+	for _, r := range rules {
+		subWindows = append(subWindows, generateSubWindowsForRule(direction, unit, start, end, r, loc)...)
+	}
+
+	subWindows = MergeSubWindows(subWindows)
+
+	return subWindows
+}
+
+func GenerateSubWindowsForRule(direction interval.Direction, unit interval.Frequency, start time.Time, end time.Time, rule Rule, loc *time.Location) []common.SubWindowResult {
+	return generateSubWindowsForRule(direction, unit, start, end, rule, loc)
+}
+
+func generateSubWindowsForRule(direction interval.Direction, unit interval.Frequency, start time.Time, end time.Time, rule Rule, loc *time.Location) []common.SubWindowResult {
 	evaluatedFrequencyUnit := adjustFrequencyUnitForRuleEvaluation(unit)
 
-	// Generate a day window for each subwindow
+	rangeStart := start
+	rangeEnd := end
+	if end.Before(start) {
+		rangeStart = end
+		rangeEnd = start
+	}
+
+	evaluationEnd := nextTimeForFrequency(rangeEnd, evaluatedFrequencyUnit)
+
 	iv := interval.New(interval.IntervalOption{
-		AnchorDate:    start,
-		StartDate:     &start,
-		EndDate:       &end,
+		AnchorDate:    rangeStart,
+		StartDate:     &rangeStart,
+		EndDate:       &evaluationEnd,
 		FrequencyUnit: evaluatedFrequencyUnit,
 		IntervalValue: 1,
 	})
 
-	times, err := iv.Between(direction, start, end, nil)
+	times, err := iv.Between(interval.DirectionForward, rangeStart, evaluationEnd, nil)
 	if err != nil {
 		return []common.SubWindowResult{}
 	}
 
 	evaluationWindow := timesToWindows(times)
 
-	subWindows := make([]common.SubWindowResult, 0, len(evaluationWindow)*len(rules))
+	subWindows := make([]common.SubWindowResult, 0, len(evaluationWindow))
 	for _, w := range evaluationWindow {
-		for _, r := range rules {
-			subWindowFilter := matchesRuleToWindow(r, w.Start, w.End)
+		subWindowFilter := matchesRuleToWindow(rule, w.Start, w.End)
 
-			if subWindowFilter == nil {
-				continue // skip rule if the rule does not match
-			}
-
-			if subWindowFilter.Start.IsZero() || subWindowFilter.End.IsZero() {
-				continue // skip rule if the rule does not match
-			}
-
-			if subWindowFilter.Start.Equal(subWindowFilter.End) || subWindowFilter.Start.After(subWindowFilter.End) {
-				continue // skip invalid windows
-			}
-
-			subWindows = append(subWindows, *subWindowFilter)
+		if subWindowFilter == nil {
+			continue // skip rule if the rule does not match
 		}
+
+		if subWindowFilter.Start.IsZero() || subWindowFilter.End.IsZero() {
+			continue // skip rule if the rule does not match
+		}
+
+		if subWindowFilter.Start.Equal(subWindowFilter.End) || subWindowFilter.Start.After(subWindowFilter.End) {
+			continue // skip invalid windows
+		}
+
+		subWindows = append(subWindows, *subWindowFilter)
 	}
 
-	subWindows = mergeSubWindows(subWindows)
+	if rule.Filter != nil {
+		subWindows = rule.Filter(subWindows)
+	}
+
 	return subWindows
 }
 
-func mergeSubWindows(subWindows []common.SubWindowResult) []common.SubWindowResult {
+func nextTimeForFrequency(t time.Time, freq interval.Frequency) time.Time {
+	switch freq {
+	case interval.FrequencyNanoSecond:
+		return t.Add(time.Nanosecond)
+	case interval.FrequencyMilliSecond:
+		return t.Add(time.Millisecond)
+	case interval.FrequencySecond:
+		return t.Add(time.Second)
+	case interval.FrequencyMinute:
+		return t.Add(time.Minute)
+	case interval.FrequencyHour:
+		return t.Add(time.Hour)
+	case interval.FrequencyDay:
+		return t.AddDate(0, 0, 1)
+	case interval.FrequencyWeek:
+		return t.AddDate(0, 0, 7)
+	case interval.FrequencyMonth:
+		return t.AddDate(0, 1, 0)
+	case interval.FrequencyQuarter:
+		return t.AddDate(0, 3, 0)
+	case interval.FrequencyYear:
+		return t.AddDate(1, 0, 0)
+	default:
+		return t
+	}
+}
+
+func MergeSubWindows(subWindows []common.SubWindowResult) []common.SubWindowResult {
 	if len(subWindows) == 0 {
 		return subWindows
 	}

--- a/rules/subwindow_test.go
+++ b/rules/subwindow_test.go
@@ -1,0 +1,81 @@
+package rules
+
+import (
+	"testing"
+	"time"
+
+	"github.com/copito/coptime/interval"
+)
+
+func TestGenerateSubWindowsForRuleTypeBidirectional(t *testing.T) {
+	base := time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC)
+	rule := Rule{
+		IntervalType: RuleTypeInclusion,
+		MonthDays:    []uint32{31},
+	}
+
+	tests := []struct {
+		name      string
+		direction interval.Direction
+		start     time.Time
+		end       time.Time
+	}{
+		{
+			name:      "forward interval",
+			direction: interval.DirectionForward,
+			start:     base,
+			end:       base.AddDate(0, 1, 0),
+		},
+		{
+			name:      "backward interval",
+			direction: interval.DirectionBackward,
+			start:     base.AddDate(0, 1, 0),
+			end:       base,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			windows := GenerateSubWindowsForRuleType(tt.direction, interval.FrequencyMonth, tt.start, tt.end, []Rule{rule}, time.UTC)
+
+			if len(windows) != 1 {
+				t.Fatalf("expected 1 window, got %d", len(windows))
+			}
+
+			expectedStart := time.Date(2024, time.January, 31, 0, 0, 0, 0, time.UTC)
+			if !windows[0].Start.Equal(expectedStart) {
+				t.Fatalf("expected window to start at %s, got %s", expectedStart, windows[0].Start)
+			}
+
+			expectedEnd := time.Date(2024, time.February, 1, 0, 0, 0, 0, time.UTC)
+			if !windows[0].End.Equal(expectedEnd) {
+				t.Fatalf("expected window to end at %s, got %s", expectedEnd, windows[0].End)
+			}
+		})
+	}
+}
+
+func TestGenerateSubWindowsForRuleAppliesFilter(t *testing.T) {
+	base := time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC)
+	rule := Rule{
+		IntervalType: RuleTypeInclusion,
+		MonthDays:    []uint32{28, 29, 30, 31},
+		Filter:       NewOccurrenceFilter([]int{-1}),
+	}
+
+	windows := GenerateSubWindowsForRule(interval.DirectionForward, interval.FrequencyMonth, base, base.AddDate(0, 1, 0), rule, time.UTC)
+	if len(windows) != 1 {
+		t.Fatalf("expected filter to reduce to one window, got %d", len(windows))
+	}
+
+	expectedStart := time.Date(2024, time.January, 31, 0, 0, 0, 0, time.UTC)
+	expectedEnd := time.Date(2024, time.February, 1, 0, 0, 0, 0, time.UTC)
+
+	if !windows[0].Start.Equal(expectedStart) {
+		t.Fatalf("expected filtered start %s, got %s", expectedStart, windows[0].Start)
+	}
+
+	if !windows[0].End.Equal(expectedEnd) {
+		t.Fatalf("expected filtered end %s, got %s", expectedEnd, windows[0].End)
+	}
+}

--- a/window/conversions.go
+++ b/window/conversions.go
@@ -92,6 +92,12 @@ func convertRRULEtoWindowOption(ruleString string) (*WindowOption, error) {
 		hasRule = true
 	}
 
+	var occurrenceIndexes []int
+	if len(rr.OrigOptions.Bysetpos) != 0 {
+		occurrenceIndexes = append(occurrenceIndexes, rr.OrigOptions.Bysetpos...)
+		hasRule = true
+	}
+
 	// For time, we can only represent a single time or a single range.
 	// RRULE can have multiple values, e.g., BYHOUR=8,18.
 	// The current TimeRange struct does not support this.
@@ -121,6 +127,9 @@ func convertRRULEtoWindowOption(ruleString string) (*WindowOption, error) {
 	}
 
 	if hasRule {
+		if len(occurrenceIndexes) > 0 {
+			rule.Filter = rules.NewOccurrenceFilter(occurrenceIndexes)
+		}
 		rulesList = append(rulesList, rule)
 	}
 

--- a/window/conversions_test.go
+++ b/window/conversions_test.go
@@ -5,10 +5,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/copito/coptime/common"
 	"github.com/copito/coptime/helper"
 	"github.com/copito/coptime/interval"
 	rules "github.com/copito/coptime/rules"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/teambition/rrule-go"
 )
 
@@ -26,6 +28,7 @@ func TestRRULEConversion(t *testing.T) {
 		rruleString          string
 		expectedWindowOption WindowOption
 		expectedError        bool
+		validate             func(t *testing.T, opt *WindowOption)
 	}{
 		{
 			name:        "Invalid RRULE",
@@ -387,6 +390,48 @@ func TestRRULEConversion(t *testing.T) {
 			},
 			expectedError: false,
 		},
+		{
+			name:        "Monthly last day with occurrence filter",
+			rruleString: "DTSTART:20240131T000000Z\nRRULE:FREQ=MONTHLY;BYSETPOS=-1;BYMONTHDAY=28,29,30,31",
+			expectedWindowOption: WindowOption{
+				IntervalOption: interval.IntervalOption{
+					AnchorDate:    time.Date(2024, time.January, 31, 0, 0, 0, 0, time.UTC),
+					StartDate:     helper.ToPointer(time.Date(2024, time.January, 31, 0, 0, 0, 0, time.UTC)),
+					EndDate:       nil,
+					Size:          &inf,
+					FrequencyUnit: interval.FrequencyMonth,
+					IntervalValue: uint32(1),
+				},
+				Rules: []rules.Rule{
+					{
+						IntervalType: rules.RuleTypeInclusion,
+						MonthDays:    []uint32{28, 29, 30, 31},
+					},
+				},
+			},
+			expectedError: false,
+			validate: func(t *testing.T, opt *WindowOption) {
+				require.NotEmpty(t, opt.Rules, "expected rules for validation")
+				if opt.Rules[0].Filter == nil {
+					t.Fatalf("expected filter to be configured")
+				}
+
+				windows := []common.SubWindowResult{
+					{Start: time.Date(2024, time.January, 28, 0, 0, 0, 0, time.UTC), End: time.Date(2024, time.January, 29, 0, 0, 0, 0, time.UTC)},
+					{Start: time.Date(2024, time.January, 29, 0, 0, 0, 0, time.UTC), End: time.Date(2024, time.January, 30, 0, 0, 0, 0, time.UTC)},
+					{Start: time.Date(2024, time.January, 30, 0, 0, 0, 0, time.UTC), End: time.Date(2024, time.January, 31, 0, 0, 0, 0, time.UTC)},
+					{Start: time.Date(2024, time.January, 31, 0, 0, 0, 0, time.UTC), End: time.Date(2024, time.February, 1, 0, 0, 0, 0, time.UTC)},
+				}
+
+				filtered := opt.Rules[0].Filter(windows)
+				require.Len(t, filtered, 1, "filter should reduce to a single window")
+
+				expected := time.Date(2024, time.January, 31, 0, 0, 0, 0, time.UTC)
+				if !filtered[0].Start.Equal(expected) {
+					t.Fatalf("expected filtered start %s, got %s", expected, filtered[0].Start)
+				}
+			},
+		},
 		// {
 		// 	name:        "Simple Daily Interval (1) With DTstart (20250101000000)",
 		// 	rruleString: "DTSTART=20240101T090000Z;FREQ=DAILY;INTERVAL=1",
@@ -516,6 +561,65 @@ func TestRRULEConversion(t *testing.T) {
 					assert.Nil(t, rule.TimeRange, "time range is nil")
 				}
 
+			}
+
+			if tt.validate != nil {
+				tt.validate(t, calculatedActual)
+			}
+		})
+	}
+}
+
+func TestWindowerFromRRULEBackwardGeneration(t *testing.T) {
+	type expectedOccurrence struct {
+		name     string
+		rrule    string
+		expected []time.Time
+	}
+
+	testCases := []expectedOccurrence{
+		{
+			name:  "last day of month backwards",
+			rrule: "DTSTART:20240131T000000Z\nRRULE:FREQ=MONTHLY;INTERVAL=1;BYSETPOS=-1;BYMONTHDAY=28,29,30,31",
+			expected: []time.Time{
+				time.Date(2024, time.January, 31, 0, 0, 0, 0, time.UTC),
+				time.Date(2023, time.December, 31, 0, 0, 0, 0, time.UTC),
+				time.Date(2023, time.November, 30, 0, 0, 0, 0, time.UTC),
+				time.Date(2023, time.October, 31, 0, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			w, err := FromRRULE(tt.rrule)
+			require.NoError(t, err)
+
+			maxAttempts := helper.ToPointer(int32(20))
+			iterator, err := w.Iterate(interval.DirectionBackward, maxAttempts)
+			require.NoError(t, err)
+
+			collected := make([]time.Time, 0, len(tt.expected))
+			for window := range iterator {
+				if len(collected) >= len(tt.expected) {
+					break
+				}
+
+				if len(window.SubWindow) == 0 {
+					continue
+				}
+
+				collected = append(collected, window.SubWindow[0].Start)
+			}
+
+			if len(collected) != len(tt.expected) {
+				t.Fatalf("expected %d occurrences, got %d", len(tt.expected), len(collected))
+			}
+
+			for i, want := range tt.expected {
+				if !collected[i].Equal(want) {
+					t.Fatalf("expected occurrence %d to be %s, got %s", i, want, collected[i])
+				}
 			}
 		})
 	}

--- a/window/rule_bindings.go
+++ b/window/rule_bindings.go
@@ -1,0 +1,38 @@
+package window
+
+import (
+	"time"
+
+	"github.com/copito/coptime/common"
+	"github.com/copito/coptime/interval"
+	rulespkg "github.com/copito/coptime/rules"
+)
+
+type ruleBinding struct {
+	rule rulespkg.Rule
+}
+
+func buildRuleBindings(opt WindowOption, ruleType rulespkg.RuleType) []ruleBinding {
+	bindings := make([]ruleBinding, 0, len(opt.Rules))
+	for _, rule := range opt.Rules {
+		if rule.IntervalType != ruleType {
+			continue
+		}
+
+		bindings = append(bindings, ruleBinding{rule: rule})
+	}
+	return bindings
+}
+
+func generateSubWindowsForBindings(direction interval.Direction, unit interval.Frequency, start time.Time, end time.Time, bindings []ruleBinding, tz *time.Location) []common.SubWindowResult {
+	if len(bindings) == 0 {
+		return []common.SubWindowResult{}
+	}
+
+	ruleSet := make([]rulespkg.Rule, 0, len(bindings))
+	for _, binding := range bindings {
+		ruleSet = append(ruleSet, binding.rule)
+	}
+
+	return rulespkg.GenerateSubWindowsForRuleType(direction, unit, start, end, ruleSet, tz)
+}

--- a/window/rule_bindings_test.go
+++ b/window/rule_bindings_test.go
@@ -1,0 +1,75 @@
+package window
+
+import (
+	"testing"
+	"time"
+
+	"github.com/copito/coptime/common"
+	"github.com/copito/coptime/interval"
+	rulespkg "github.com/copito/coptime/rules"
+)
+
+func TestBuildRuleBindingsFiltersByType(t *testing.T) {
+	opt := WindowOption{
+		Rules: []rulespkg.Rule{
+			{IntervalType: rulespkg.RuleTypeInclusion},
+			{IntervalType: rulespkg.RuleTypeExclusion},
+		},
+	}
+
+	includes := buildRuleBindings(opt, rulespkg.RuleTypeInclusion)
+	if len(includes) != 1 {
+		t.Fatalf("expected 1 inclusion binding, got %d", len(includes))
+	}
+
+	excludes := buildRuleBindings(opt, rulespkg.RuleTypeExclusion)
+	if len(excludes) != 1 {
+		t.Fatalf("expected 1 exclusion binding, got %d", len(excludes))
+	}
+}
+
+func TestGenerateSubWindowsForBindingsAppliesRuleFilters(t *testing.T) {
+	start := time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2024, time.February, 1, 0, 0, 0, 0, time.UTC)
+
+	binding := ruleBinding{
+		rule: rulespkg.Rule{
+			IntervalType: rulespkg.RuleTypeInclusion,
+			MonthDays:    []uint32{28, 29, 30, 31},
+			Filter:       rulespkg.NewOccurrenceFilter([]int{-1}),
+		},
+	}
+
+	windows := generateSubWindowsForBindings(interval.DirectionForward, interval.FrequencyMonth, start, end, []ruleBinding{binding}, time.UTC)
+	if len(windows) != 1 {
+		t.Fatalf("expected a single filtered window, got %d", len(windows))
+	}
+
+	expectedStart := time.Date(2024, time.January, 31, 0, 0, 0, 0, time.UTC)
+	expectedEnd := expectedStart.AddDate(0, 0, 1)
+
+	if !windows[0].Start.Equal(expectedStart) {
+		t.Fatalf("expected start %s, got %s", expectedStart, windows[0].Start)
+	}
+
+	if !windows[0].End.Equal(expectedEnd) {
+		t.Fatalf("expected end %s, got %s", expectedEnd, windows[0].End)
+	}
+
+	// verify filters do not mutate the original slice and still produce sorted output
+	raw := []common.SubWindowResult{
+		{Start: start.AddDate(0, 0, 27), End: start.AddDate(0, 0, 28)},
+		{Start: start.AddDate(0, 0, 28), End: start.AddDate(0, 0, 29)},
+		{Start: start.AddDate(0, 0, 29), End: start.AddDate(0, 0, 30)},
+		{Start: start.AddDate(0, 0, 30), End: start.AddDate(0, 0, 31)},
+	}
+
+	filtered := binding.rule.Filter(raw)
+	if len(filtered) != 1 {
+		t.Fatalf("expected filtered result length 1, got %d", len(filtered))
+	}
+
+	if !filtered[0].Start.Equal(expectedStart) {
+		t.Fatalf("expected filtered start %s, got %s", expectedStart, filtered[0].Start)
+	}
+}

--- a/window/window.go
+++ b/window/window.go
@@ -111,13 +111,13 @@ func (w *Windower) Iterate(direction interval.Direction, maxAttempt *int32) (ite
 	}
 
 	// Handle rules
-	includes := rules.FilterRules(w.opt.Rules, rules.RuleTypeInclusion)
-	excludes := rules.FilterRules(w.opt.Rules, rules.RuleTypeExclusion)
+	includeBindings := buildRuleBindings(w.opt, rules.RuleTypeInclusion)
+	excludeBindings := buildRuleBindings(w.opt, rules.RuleTypeExclusion)
 
 	// Create a include window with the entire range if no inclusion rules are defined
-	if len(includes) == 0 {
+	if len(includeBindings) == 0 {
 		completeInclusion := rules.CreateCompleteInclusionRule(*w.opt.StartDate, *w.opt.EndDate)
-		includes = append(includes, completeInclusion)
+		includeBindings = append(includeBindings, ruleBinding{rule: completeInclusion})
 	}
 
 	// Safe-guard: avoid infinite loop
@@ -153,10 +153,10 @@ func (w *Windower) Iterate(direction interval.Direction, maxAttempt *int32) (ite
 			var subWindows []common.SubWindowResult
 
 			// 1. Apply inclusion rules
-			additiveSubWindows := rules.GenerateSubWindowsForRuleType(direction, w.opt.FrequencyUnit, previousTime, nextTime, includes, tz)
+			additiveSubWindows := generateSubWindowsForBindings(direction, w.opt.FrequencyUnit, previousTime, nextTime, includeBindings, tz)
 
 			// 2. Apply exclusion rules
-			subtractiveSubWindows := rules.GenerateSubWindowsForRuleType(direction, w.opt.FrequencyUnit, previousTime, nextTime, excludes, tz)
+			subtractiveSubWindows := generateSubWindowsForBindings(direction, w.opt.FrequencyUnit, previousTime, nextTime, excludeBindings, tz)
 
 			// 3. Combine additive and subtractive sub-windows
 			subWindows = rules.SubtractSubwindowsFromAdditives(additiveSubWindows, subtractiveSubWindows)


### PR DESCRIPTION
## Summary
- add a generic occurrence filter to rules so windows can reduce rule results without storing set-position metadata
- map RRULE BYSETPOS values to the new filter when converting into window options and simplify rule binding helpers to rely on per-rule filters
- extend tests to cover occurrence filtering, RRULE conversion validation, and backward iteration for last-day-of-month schedules

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68e0858663608328a5abfedc4a38126f